### PR TITLE
Linux: Update hs_platform_info with `Default` implementation

### DIFF
--- a/hyperscan-sys/src/linux/raw.rs
+++ b/hyperscan-sys/src/linux/raw.rs
@@ -506,7 +506,7 @@ pub type hs_compile_error_t = hs_compile_error;
 /// A hs_platform_info structure may be populated for the current platform by
 /// using the @ref hs_populate_platform() call.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct hs_platform_info {
     /// Information about the target platform which may be used to guide the
     /// optimisation process of the compile.


### PR DESCRIPTION
Without that I got an error when compiled on WSL2:
```rust
error[E0277]: the trait bound `hs_platform_info: Default` is not satisfied
--> /home/mat/.cargo/git/checkouts/rust-hyperscan-d643747395983474/6a4d890/hyperscan/src/api.rs:184:40
|
184 | PlatformInfo(Some(RefCell::new(hs_platform_info_t {
| ________________________________________^
185 | | tune,
186 | | cpu_features,
187 | | reserved1: 0,
188 | | reserved2: 0,
189 | | ..Default::default()
190 | | })))
| |_________^ the trait `Default` is not implemented for `hs_platform_info`
|
= note: required by `std::default::Default::default`
```